### PR TITLE
Add newlines between migration guide variants

### DIFF
--- a/packages/size-limit/create-help.js
+++ b/packages/size-limit/create-help.js
@@ -79,10 +79,13 @@ module.exports = process => {
       '',
       'For application, where you send JS bundle directly to users',
       '  ' + y(add + '@size-limit/preset-app'),
+      '',
       'For frameworks, components and big libraries',
       '  ' + y(add + '@size-limit/preset-big-lib'),
+      '',
       'For small (< 10 KB) libraries',
       '  ' + y(add + '@size-limit/preset-small-lib'),
+      '',
       'Check out docs for more complicated cases',
       '  ' + y('https://github.com/ai/size-limit/')
     )


### PR DESCRIPTION
It's easier to read this way, and more clear to what case which command corresponds